### PR TITLE
Bump RxDart to 0.24.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,10 +9,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  rxdart: ^0.23.1
+  rxdart: ^0.24.1
   esc_pos_utils: ^0.3.6
   # esc_pos_utils:
-    # path: ../esc_pos_utils
+  # path: ../esc_pos_utils
   flutter_bluetooth_basic: ^0.1.5
 
 dev_dependencies:


### PR DESCRIPTION
Tested locally.

Requires andrey-ushakov/flutter_bluetooth_basic/pull/13.