### PR TITLE
wrapped timeout in try catch

### DIFF
--- a/lib/src/printer_bluetooth_manager.dart
+++ b/lib/src/printer_bluetooth_manager.dart
@@ -133,9 +133,13 @@ class PrinterBluetoothManager {
 
     // Printing timeout
     _runDelayed(timeout).then((dynamic v) async {
-      if (_isPrinting) {
-        _isPrinting = false;
-        completer.complete(PosPrintResult.timeout);
+      try {
+        if (_isPrinting) {
+          _isPrinting = false;
+          completer.complete(PosPrintResult.timeout);
+        }
+      } catch (e, stacktrace) {
+        print('$e, ${[stacktrace]}');
       }
     });
 


### PR DESCRIPTION
To avoid an exception of "Bad State: Future already completed.", I wrapped the _runDelayed body in a try catch to log and suppress any errors.

See issues #51 and #58 
